### PR TITLE
fix(deps): update dependency symfony/http-foundation to v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-      "symfony/http-foundation": "^4.4.9 || ^6.2.7"
+      "symfony/http-foundation": "^4.4.9 || ^6.2.7 || ^7.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "7.5.20"


### PR DESCRIPTION
Updates to symfony/http-foundation v7, so Drupal 11 is supported.